### PR TITLE
Google Map Key fix.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="@string/key"/>
+            android:value="@string/google_maps_api_key"/>
 
         <activity
             android:name=".actMainPage"


### PR DESCRIPTION
The README specifies the map key should be named google_maps_api_key, but manifest expects key.
